### PR TITLE
feat(longhorn): add longhorn disks

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
       defaultClass: false
     defaultSettings:
       #backupTarget: "nfs://${NFS_SERVER}:/dumpster/backups/apps/longhorn"
-      defaultDataPath: /var/lib/longhorn_data
+      defaultDataPath: /var/mnt/longhorn-data
       defaultReplicaCount: 2
       storageMinimalAvailablePercentage: 10
     # ingress:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -23,6 +23,15 @@ nodes:
     ipAddress: "172.29.51.31"
     installDiskSelector:
       model: APPLE*
+    userVolumes:
+      - name: longhorn-data
+        provisioning:
+          minSize: 500Gi
+          grow: true
+          diskSelector:
+            match: disk.transport == "usb"
+        filesystem:
+          type: ext4
     machineSpec:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/55b1dc45bfa8333d821de58d13266eee99d3000b45f76a02e3d9ce79d6a0c045
@@ -38,6 +47,15 @@ nodes:
     ipAddress: "172.29.51.32"
     installDiskSelector:
       model: APPLE*
+    userVolumes:
+      - name: longhorn-data
+        provisioning:
+          minSize: 500Gi
+          grow: true
+          diskSelector:
+            match: disk.transport == "usb"
+        filesystem:
+          type: ext4
     machineSpec:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/55b1dc45bfa8333d821de58d13266eee99d3000b45f76a02e3d9ce79d6a0c045
@@ -53,6 +71,15 @@ nodes:
     ipAddress: "172.29.51.33"
     installDiskSelector:
       model: APPLE*
+    userVolumes:
+      - name: longhorn-data
+        provisioning:
+          minSize: 500Gi
+          grow: true
+          diskSelector:
+            match: disk.transport == "usb"
+        filesystem:
+          type: ext4
     machineSpec:
       secureboot: false
     talosImageURL: factory.talos.dev/installer/55b1dc45bfa8333d821de58d13266eee99d3000b45f76a02e3d9ce79d6a0c045


### PR DESCRIPTION
Add mountpoints for longhorn disks to talhelper config.

Update longhorn defaultDataPath to point to user volume